### PR TITLE
Editorial edits preparing draft for publication

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -123,7 +123,6 @@
   title: Package-URL (PURL) specification
   date: 2025-12-06
   shortname: ECMA-xxx
-  date: 2025-12-06
   status: standard
   location: https://tc54.org/ecmaXXX/
   markEffects: true
@@ -221,7 +220,7 @@
 
 <emu-clause id="sec-purl-specification">
   <h1>Package-URL specification</h1>
-  <p>PURL stands for <strong>Package URL</strong>.</p>
+  <p>PURL stands for <strong>Package-URL</strong>.</p>
   <p>A PURL is a URL composed of seven components:</p>
   <pre>
     <code lang="plaintext">
@@ -244,7 +243,7 @@
       <tr>
         <td>scheme</td>
         <td>Required</td>
-        <td>The URL scheme with the constant value of "pkg". One of the primary reasons for this single scheme is to facilitate the future official registration of the "pkg" scheme for package URLs.</td>
+        <td>The URL scheme with the constant value of "pkg". One of the primary reasons for this single scheme is to facilitate the future official registration of the "pkg" scheme for Package-URLs.</td>
       </tr>
       <tr>
         <td>type</td>
@@ -624,7 +623,7 @@
           <td>use_repository</td>
           <td>Boolean</td>
           <td>Required</td>
-          <td>true if this PURL type uses a public package repository.</td>
+          <td>`true` if this PURL type uses a public package repository.</td>
         </tr>
         <tr>
           <td>default_repository_url</td>
@@ -646,7 +645,7 @@
       <p class="properties"><strong>Location:</strong> /repository/use_repository<br>
         <strong>Property:</strong> use_repository (Required)<br>
         <strong>Type:</strong> Boolean</p>
-      <p>true if this PURL type uses a public package repository.</p>
+      <p>`true` if this PURL type uses a public package repository.</p>
     </emu-clause>
 
     <emu-clause id="sec--repository-default-repository-url">
@@ -701,7 +700,7 @@
           <td>case_sensitive</td>
           <td>Boolean</td>
           <td>Optional</td>
-          <td>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</td>
+          <td>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</td>
         </tr>
         <tr>
           <td>normalization_rules</td>
@@ -773,8 +772,8 @@
       <p class="properties"><strong>Location:</strong> /namespace_definition/case_sensitive<br>
         <strong>Property:</strong> case_sensitive (Optional)<br>
         <strong>Type:</strong> Boolean<br>
-        <strong>Default Value:</strong> true</p>
-      <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
+        <strong>Default Value:</strong> `true`</p>
+      <p>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-normalization-rules">
@@ -837,7 +836,7 @@
           <td>case_sensitive</td>
           <td>Boolean</td>
           <td>Optional</td>
-          <td>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</td>
+          <td>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</td>
         </tr>
         <tr>
           <td>normalization_rules</td>
@@ -893,8 +892,8 @@
       <p class="properties"><strong>Location:</strong> /name_definition/case_sensitive<br>
         <strong>Property:</strong> case_sensitive (Optional)<br>
         <strong>Type:</strong> Boolean<br>
-        <strong>Default Value:</strong> true</p>
-      <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
+        <strong>Default Value:</strong> `true`</p>
+      <p>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--name-definition-normalization-rules">
@@ -957,7 +956,7 @@
           <td>case_sensitive</td>
           <td>Boolean</td>
           <td>Optional</td>
-          <td>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</td>
+          <td>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</td>
         </tr>
         <tr>
           <td>normalization_rules</td>
@@ -1013,8 +1012,8 @@
       <p class="properties"><strong>Location:</strong> /version_definition/case_sensitive<br>
         <strong>Property:</strong> case_sensitive (Optional)<br>
         <strong>Type:</strong> Boolean<br>
-        <strong>Default Value:</strong> true</p>
-      <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
+        <strong>Default Value:</strong> `true`</p>
+      <p>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--version-definition-normalization-rules">
@@ -1191,7 +1190,7 @@
           <td>case_sensitive</td>
           <td>Boolean</td>
           <td>Optional</td>
-          <td>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</td>
+          <td>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</td>
         </tr>
         <tr>
           <td>normalization_rules</td>
@@ -1247,8 +1246,8 @@
       <p class="properties"><strong>Location:</strong> /subpath_definition/case_sensitive<br>
         <strong>Property:</strong> case_sensitive (Optional)<br>
         <strong>Type:</strong> Boolean<br>
-        <strong>Default Value:</strong> true</p>
-      <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
+        <strong>Default Value:</strong> `true`</p>
+      <p>`true` if this PURL component is case sensitive. If `false`, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--subpath-definition-normalization-rules">

--- a/spec.html
+++ b/spec.html
@@ -109,11 +109,21 @@
   #sec-schemas pre {
     break-inside: auto;
   }
+
+  p.properties + p, ol {
+    break-before: avoid;
+  }
+
+  /* First edition (2025-specific) changes, reassess in future editions */
+  #sec--name-definition-requirement p.properties + p {
+    break-after: avoid;
+  }
 </style>
 <pre class="metadata">
   title: Package-URL (PURL) specification
   date: 2025-12-06
   shortname: ECMA-xxx
+  date: 2025-12-06
   status: standard
   location: https://tc54.org/ecmaXXX/
   markEffects: true
@@ -173,38 +183,21 @@
 
 <emu-clause id="sec-conformance">
   <h1>Conformance</h1>
-  <emu-clause id="sec-requirements-terminology">
-    <h1>Requirements terminology</h1>
-    <p>In this Standard, the words that are used to define the significance of each requirement are detailed below. These words are used in accordance with their definitions in <a href="https://www.ietf.org/rfc/rfc2119.txt">RFC 2119</a>, and their respective meanings are reproduced below:</p>
-    <ul>
-      <li>Must: This word, or the adjective “required” and the auxiliary verb "shall", means that the item is an absolute requirement of the standard.</li>
-      <li>Should: This word, or the adjective “recommended”, means that there might exist valid reasons in particular circumstances to ignore this item, but the full implications should be understood and the case carefully weighed before making an implementation decision.</li>
-      <li>May: This word, or the adjective “optional”, means that this item is truly optional.</li>
-    </ul>
-    <p>The words "must not", "shall not", "should not", and "not recommended", are the negative forms of "must", "shall", "should", and "recommended", respectively. There is no negative form of "may".</p>
-  </emu-clause>
-  <emu-clause id="sec-implementation-conformance">
-    <h1>Implementation conformance</h1>
-    <p>A conforming implementation of Package-URL (PURL) must fully implement and support all elements defined within this Standard, including the syntax, components, and semantic requirements for constructing and interpreting valid PURLs.</p>
-    <p>A conforming implementation of PURL must adhere to the syntax defined in this Standard, ensuring that all PURLs are parsed, constructed, and validated according to the prescribed rules. The implementation must provide full support for ecosystem-agnostic behaviour, enabling PURLs to function consistently and reliably across diverse environments.</p>
-    <p>All required components of a PURL, such as the scheme, type, and name, must be present and validated according to the rules defined in this Standard. Additionally, optional components, including qualifiers and subpaths, must be handled appropriately if provided, in full compliance with their specified behaviours.</p>
-    <p>Implementations must ensure that equivalent PURLs are consistently resolved to the same canonical representation. This includes strict adherence to normalisation and equivalence rules. Furthermore, implementations must process URI encoding and decoding for PURL components according to the standards outlined in RFC 3986.</p>
-    <p>Invalid PURLs that fail to conform to the specification must be identified and rejected by any conforming implementation. This guarantees the integrity and reliability of PURLs in all supported contexts.</p>
-    <p>A conforming implementation of PURL may extend its functionality by providing ecosystem-specific validation, processing, or metadata handling, as long as these extensions do not violate the core specification. Additionally, implementations may offer auxiliary tools or features, such as utilities for constructing or validating PURLs, provided they align with the standard's requirements.</p>
-    <p>A conforming implementation must not redefine or alter the core syntax, components, or semantics defined by this Standard. Any prohibited extensions explicitly identified in the specification must not be implemented. Furthermore, behaviours that compromise the interoperability of PURLs across tools, platforms, or ecosystems are strictly disallowed.</p>
-  </emu-clause>
+  <p>A conforming implementation of Package-URL (PURL) must fully implement and support all elements defined within this Standard, including the syntax, components, and semantic requirements for constructing and interpreting valid PURLs.</p>
+  <p>A conforming implementation of PURL must adhere to the syntax defined in this Standard, ensuring that all PURLs are parsed, constructed, and validated according to the prescribed rules. The implementation must provide full support for ecosystem-agnostic behaviour, enabling PURLs to function consistently and reliably across diverse environments.</p>
+  <p>All required components of a PURL, such as the scheme, type, and name, must be present and validated according to the rules defined in this Standard. Additionally, optional components, including qualifiers and subpaths, must be handled appropriately if provided, in full compliance with their specified behaviours.</p>
+  <p>Implementations must ensure that equivalent PURLs are consistently resolved to the same canonical representation. This includes strict adherence to normalisation and equivalence rules. Furthermore, implementations must process URI encoding and decoding for PURL components according to the standards outlined in RFC 3986.</p>
+  <p>Invalid PURLs that fail to conform to the specification must be identified and rejected by any conforming implementation. This guarantees the integrity and reliability of PURLs in all supported contexts.</p>
+  <p>A conforming implementation of PURL may extend its functionality by providing ecosystem-specific validation, processing, or metadata handling, as long as these extensions do not violate the core specification. Additionally, implementations may offer auxiliary tools or features, such as utilities for constructing or validating PURLs, provided they align with the standard's requirements.</p>
+  <p>A conforming implementation must not redefine or alter the core syntax, components, or semantics defined by this Standard. Any prohibited extensions explicitly identified in the specification must not be implemented. Furthermore, behaviours that compromise the interoperability of PURLs across tools, platforms, or ecosystems are strictly disallowed.</p>
 </emu-clause>
 
 <emu-clause id="sec-normative-references">
   <h1>Normative references</h1>
   <p>The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
   <p>
-    ECMA-404, <i>The JSON Data Interchange Format</i><br>
-    <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-404/">https://www.ecma-international.org/publications-and-standards/standards/ecma-404/</a>
-  </p>
-  <p>
-    INCITS 4-1986 [R2022], <i>Information Systems - Coded Character Sets - 7-Bit Standard Code for Information Interchange (7-Bit ASCII)</i><br>
-    <a href="https://webstore.ansi.org/standards/incits/incits1986r2022">https://webstore.ansi.org/standards/incits/incits1986r2022</a>
+    ECMA-262, <i>ECMAScript® language specification</i><br>
+    <a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">https://ecma-international.org/publications-and-standards/standards/ecma-262/</a>
   </p>
   <p>
     RFC 3986, <i>Uniform Resource Identifier (URI): Generic Syntax</i><br>
@@ -213,10 +206,6 @@
   <p>
     The Unicode Standard<br>
     <a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a>
-  </p>
-  <p>
-    IETF Draft, March 2018, <i>JSON Schema Validation: A Vocabulary for Structural Validation of JSON (Draft-07)</i><br>
-    <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01">https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01</a>
   </p>
 </emu-clause>
 
@@ -373,7 +362,7 @@
         </ul>
       </li>
       <li>Where the space ' ' is permitted, it must be percent-encoded as '%20'.</li>
-      <li>With the exception of the percent-encoding mechanism, the rules regarding percent-encoding are defined by this specification alone.</li>
+      <li>With the exception of the percent-encoding mechanism, the rules regarding percent-encoding are defined by this Standard alone.</li>
     </ul>
   </emu-clause>
 
@@ -493,8 +482,10 @@
     generate PURL type documentation and to support PURL libraries and tools so that they can more easily parse, build,
     and validate PURLs by type in a consistent and standardized manner across programing languages and technology stacks.
   </p>
-  <br><strong>Location:</strong> /<br>
-  <strong>Type:</strong> Object<br>
+  <p class="properties">
+    <strong>Location:</strong> /<br>
+    <strong>Type:</strong> Object
+  </p>
   <p>Schema to specify a Package-URL (PURL) type as a structured definition.</p>
   <emu-table>
     <emu-caption id="caption-1">Properties for the root object</emu-caption>
@@ -584,10 +575,10 @@
 
   <emu-clause id="sec--type">
     <h1>PURL type</h1>
-    <br><strong>Location:</strong> /type<br>
-    <strong>Property:</strong> type (Required)<br>
-    <strong>Type:</strong> String<br>
-    <strong>Pattern Constraint:</strong> <code class="pattern">^[a-z][a-z0-9-\.]+$</code><br>
+    <p class="properties"><strong>Location:</strong> /type<br>
+      <strong>Property:</strong> type (Required)<br>
+      <strong>Type:</strong> String<br>
+      <strong>Pattern Constraint:</strong> <code class="pattern">^[a-z][a-z0-9-\.]+$</code></p>
     <p>The type string for this Package-URL type.</p>
     <emu-example> maven</emu-example>
     <emu-example> npm</emu-example>
@@ -596,9 +587,9 @@
 
   <emu-clause id="sec--type-name">
     <h1>Type name</h1>
-    <br><strong>Location:</strong> /type_name<br>
-    <strong>Property:</strong> type_name (Required)<br>
-    <strong>Type:</strong> String<br>
+    <p class="properties"><strong>Location:</strong> /type_name<br>
+      <strong>Property:</strong> type_name (Required)<br>
+      <strong>Type:</strong> String</p>
     <p>The name for this PURL type.</p>
     <emu-example> Apache Maven</emu-example>
     <emu-example> Python Package</emu-example>
@@ -606,17 +597,17 @@
 
   <emu-clause id="sec--description">
     <h1>Description</h1>
-    <br><strong>Location:</strong> /description<br>
-    <strong>Property:</strong> description (Required)<br>
-    <strong>Type:</strong> String<br>
+    <p class="properties"><strong>Location:</strong> /description<br>
+      <strong>Property:</strong> description (Required)<br>
+      <strong>Type:</strong> String</p>
     <p>The description of this PURL type.</p>
   </emu-clause>
 
   <emu-clause id="sec--repository">
     <h1>Repository</h1>
-    <br><strong>Location:</strong> /repository<br>
-    <strong>Property:</strong> repository (Required)<br>
-    <strong>Type:</strong> Object<br>
+    <p class="properties"><strong>Location:</strong> /repository<br>
+      <strong>Property:</strong> repository (Required)<br>
+      <strong>Type:</strong> Object</p>
     <p>The package repository usage for this PURL type.</p>
     <emu-table>
       <emu-caption id="caption-5">Properties for the repository object</emu-caption>
@@ -652,35 +643,35 @@
 
     <emu-clause id="sec--repository-use-repository">
       <h1>Use repository</h1>
-      <br><strong>Location:</strong> /repository/use_repository<br>
-      <strong>Property:</strong> use_repository (Required)<br>
-      <strong>Type:</strong> Boolean<br>
+      <p class="properties"><strong>Location:</strong> /repository/use_repository<br>
+        <strong>Property:</strong> use_repository (Required)<br>
+        <strong>Type:</strong> Boolean</p>
       <p>true if this PURL type uses a public package repository.</p>
     </emu-clause>
 
     <emu-clause id="sec--repository-default-repository-url">
       <h1>Default repository URL</h1>
-      <br><strong>Location:</strong> /repository/default_repository_url<br>
-      <strong>Property:</strong> default_repository_url (Optional)<br>
-      <strong>Type:</strong> String<br>
-      <strong>Format:</strong> URI as specified in <a href="https://www.ietf.org/rfc/rfc3986.html">RFC 3986</a><br>
+      <p class="properties"><strong>Location:</strong> /repository/default_repository_url<br>
+        <strong>Property:</strong> default_repository_url (Optional)<br>
+        <strong>Type:</strong> String<br>
+        <strong>Format:</strong> URI as specified in <a href="https://www.ietf.org/rfc/rfc3986.html">RFC 3986</a></p>
       <p>The default public repository URL for this PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--repository-note">
       <h1>Note</h1>
-      <br><strong>Location:</strong> /repository/note<br>
-      <strong>Property:</strong> note (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /repository/note<br>
+        <strong>Property:</strong> note (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>Extra note text.</p>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec--namespace-definition">
     <h1>Namespace definition</h1>
-    <br><strong>Location:</strong> /namespace_definition<br>
-    <strong>Property:</strong> namespace_definition (Required)<br>
-    <strong>Type:</strong> Object<br>
+    <p class="properties"><strong>Location:</strong> /namespace_definition<br>
+      <strong>Property:</strong> namespace_definition (Required)<br>
+      <strong>Type:</strong> Object</p>
     <p>Definition of the namespace component for this PURL type. The PURL namespace component must be required, optional or prohibited for a specific PURL type definition.</p>
 
     <emu-table>
@@ -704,7 +695,7 @@
           <td>permitted_characters</td>
           <td>String</td>
           <td>Optional</td>
-          <td>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
+          <td>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
         </tr>
         <tr>
           <td>case_sensitive</td>
@@ -735,9 +726,9 @@
 
     <emu-clause id="sec--namespace-definition-requirement">
       <h1>Namespace requirement</h1>
-      <br><strong>Location:</strong> /namespace_definition/requirement<br>
-      <strong>Property:</strong> requirement (Required)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /namespace_definition/requirement<br>
+        <strong>Property:</strong> requirement (Required)<br>
+        <strong>Type:</strong> String</p>
       <p>States that the PURL namespace component is optional, required or prohibited for a PURL type.</p>
       <p><em>Must be one of:</em></p>
       <ol>
@@ -749,74 +740,74 @@
 
     <emu-clause id="sec--namespace-definition-requirement-1">
       <h1>Component optional requirement</h1>
-      <strong>Type:</strong> String<br>
-      <strong>Constant:</strong> optional<br>
+      <p class="properties"><strong>Type:</strong> String<br>
+        <strong>Constant:</strong> optional</p>
       <p>States that this PURL component is optional for a PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-requirement-2">
       <h1>Component required requirement</h1>
-      <strong>Type:</strong> String<br>
-      <strong>Constant:</strong> required<br>
+      <p class="properties"><strong>Type:</strong> String<br>
+        <strong>Constant:</strong> required</p>
       <p>States that this PURL component is required for a PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-requirement-3">
       <h1>Component prohibited requirement</h1>
-      <strong>Type:</strong> String<br>
-      <strong>Constant:</strong> prohibited<br>
+      <p class="properties"><strong>Type:</strong> String<br>
+        <strong>Constant:</strong> prohibited</p>
       <p>States that this PURL component is prohibited for a PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-permitted-characters">
       <h1>Permitted characters in this PURL component</h1>
-      <br><strong>Location:</strong> /namespace_definition/permitted_characters<br>
-      <strong>Property:</strong> permitted_characters (Optional)<br>
-      <strong>Type:</strong> String<br>
-      <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a><br>
-      <p>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
+      <p class="properties"><strong>Location:</strong> /namespace_definition/permitted_characters<br>
+        <strong>Property:</strong> permitted_characters (Optional)<br>
+        <strong>Type:</strong> String<br>
+        <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a></p>
+      <p>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-case-sensitive">
       <h1>Case sensitive</h1>
-      <br><strong>Location:</strong> /namespace_definition/case_sensitive<br>
-      <strong>Property:</strong> case_sensitive (Optional)<br>
-      <strong>Type:</strong> Boolean<br>
-      <strong>Default Value:</strong> true<br>
+      <p class="properties"><strong>Location:</strong> /namespace_definition/case_sensitive<br>
+        <strong>Property:</strong> case_sensitive (Optional)<br>
+        <strong>Type:</strong> Boolean<br>
+        <strong>Default Value:</strong> true</p>
       <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-normalization-rules">
       <h1>Normalization rules</h1>
-      <br><strong>Location:</strong> /namespace_definition/normalization_rules<br>
-      <strong>Property:</strong> normalization_rules (Optional)<br>
-      <strong>Type:</strong> array (of String)<br>
+      <p class="properties"><strong>Location:</strong> /namespace_definition/normalization_rules<br>
+        <strong>Property:</strong> normalization_rules (Optional)<br>
+        <strong>Type:</strong> array (of String)</p>
       <p>List of rules to normalize this component for this PURL type. These are plain text, unstructured rules as some require programming and cannot be enforced only with a schema. Tools are expected to apply these rules programmatically. Each item of this array must be a string.</p>
       <p><em>All items must be unique.</em></p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-native-name">
       <h1>Native name</h1>
-      <br><strong>Location:</strong> /namespace_definition/native_name<br>
-      <strong>Property:</strong> native_name (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /namespace_definition/native_name<br>
+        <strong>Property:</strong> native_name (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>The native name of this PURL component in the package ecosystem. For instance, the 'namespace' for the 'maven' type is 'groupId', and 'scope' for the 'npm' PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--namespace-definition-note">
       <h1>Note</h1>
-      <br><strong>Location:</strong> /namespace_definition/note<br>
-      <strong>Property:</strong> note (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /namespace_definition/note<br>
+        <strong>Property:</strong> note (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>Extra note text.</p>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec--name-definition">
     <h1>Name definition</h1>
-    <br><strong>Location:</strong> /name_definition<br>
-    <strong>Property:</strong> name_definition (Required)<br>
-    <strong>Type:</strong> Object<br>
+    <p class="properties"><strong>Location:</strong> /name_definition<br>
+      <strong>Property:</strong> name_definition (Required)<br>
+      <strong>Type:</strong> Object</p>
     <p>Definition of the name component for this PURL type. The PURL name component is required for all PURL type definitions.</p>
 
     <emu-table>
@@ -840,7 +831,7 @@
           <td>permitted_characters</td>
           <td>String</td>
           <td>Optional</td>
-          <td>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
+          <td>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
         </tr>
         <tr>
           <td>case_sensitive</td>
@@ -871,9 +862,9 @@
 
     <emu-clause id="sec--name-definition-requirement">
       <h1>Name component requirement</h1>
-      <br><strong>Location:</strong> /name_definition/requirement<br>
-      <strong>Property:</strong> requirement (Required)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /name_definition/requirement<br>
+        <strong>Property:</strong> requirement (Required)<br>
+        <strong>Type:</strong> String</p>
       <p>States that the PURL name component is always required.</p>
       <p><em>Must be one of:</em></p>
       <ol>
@@ -883,60 +874,60 @@
 
     <emu-clause id="sec--name-definition-requirement-1">
       <h1>Component required requirement</h1>
-      <strong>Type:</strong> String<br>
-      <strong>Constant:</strong> required<br>
+      <p class="properties"><strong>Type:</strong> String<br>
+        <strong>Constant:</strong> required</p>
       <p>States that this PURL component is required for a PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--name-definition-permitted-characters">
       <h1>Permitted characters in this PURL component</h1>
-      <br><strong>Location:</strong> /name_definition/permitted_characters<br>
-      <strong>Property:</strong> permitted_characters (Optional)<br>
-      <strong>Type:</strong> String<br>
-      <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a><br>
-      <p>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
+      <p class="properties"><strong>Location:</strong> /name_definition/permitted_characters<br>
+        <strong>Property:</strong> permitted_characters (Optional)<br>
+        <strong>Type:</strong> String<br>
+        <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a></p>
+      <p>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
     </emu-clause>
 
     <emu-clause id="sec--name-definition-case-sensitive">
       <h1>Case sensitive</h1>
-      <br><strong>Location:</strong> /name_definition/case_sensitive<br>
-      <strong>Property:</strong> case_sensitive (Optional)<br>
-      <strong>Type:</strong> Boolean<br>
-      <strong>Default Value:</strong> true<br>
+      <p class="properties"><strong>Location:</strong> /name_definition/case_sensitive<br>
+        <strong>Property:</strong> case_sensitive (Optional)<br>
+        <strong>Type:</strong> Boolean<br>
+        <strong>Default Value:</strong> true</p>
       <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--name-definition-normalization-rules">
       <h1>Normalization rules</h1>
-      <br><strong>Location:</strong> /name_definition/normalization_rules<br>
-      <strong>Property:</strong> normalization_rules (Optional)<br>
-      <strong>Type:</strong> array (of String)<br>
+      <p class="properties"><strong>Location:</strong> /name_definition/normalization_rules<br>
+        <strong>Property:</strong> normalization_rules (Optional)<br>
+        <strong>Type:</strong> array (of String)</p>
       <p>List of rules to normalize this component for this PURL type. These are plain text, unstructured rules as some require programming and cannot be enforced only with a schema. Tools are expected to apply these rules programmatically. Each item of this array must be a string.</p>
       <p><em>All items must be unique.</em></p>
     </emu-clause>
 
     <emu-clause id="sec--name-definition-native-name">
       <h1>Native name</h1>
-      <br><strong>Location:</strong> /name_definition/native_name<br>
-      <strong>Property:</strong> native_name (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /name_definition/native_name<br>
+        <strong>Property:</strong> native_name (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>The native name of this PURL component in the package ecosystem. For instance, the 'namespace' for the 'maven' type is 'groupId', and 'scope' for the 'npm' PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--name-definition-note">
       <h1>Note</h1>
-      <br><strong>Location:</strong> /name_definition/note<br>
-      <strong>Property:</strong> note (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /name_definition/note<br>
+        <strong>Property:</strong> note (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>Extra note text.</p>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec--version-definition">
     <h1>Version definition</h1>
-    <br><strong>Location:</strong> /version_definition<br>
-    <strong>Property:</strong> version_definition (Optional)<br>
-    <strong>Type:</strong> Object<br>
+    <p class="properties"><strong>Location:</strong> /version_definition<br>
+      <strong>Property:</strong> version_definition (Optional)<br>
+      <strong>Type:</strong> Object</p>
     <p>Definition of the version component for this PURL type. The PURL version component is optional for a specific PURL type definition.</p>
 
     <emu-table>
@@ -960,7 +951,7 @@
           <td>permitted_characters</td>
           <td>String</td>
           <td>Optional</td>
-          <td>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
+          <td>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
         </tr>
         <tr>
           <td>case_sensitive</td>
@@ -991,9 +982,9 @@
 
     <emu-clause id="sec--version-definition-requirement">
       <h1>Version requirement</h1>
-      <br><strong>Location:</strong> /version_definition/requirement<br>
-      <strong>Property:</strong> requirement (Required)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /version_definition/requirement<br>
+        <strong>Property:</strong> requirement (Required)<br>
+        <strong>Type:</strong> String</p>
       <p>States that the PURL version is optional.</p>
       <p><em>Must be one of:</em></p>
       <ol>
@@ -1003,66 +994,66 @@
 
     <emu-clause id="sec--version-definition-requirement-1">
       <h1>Component optional requirement</h1>
-      <strong>Type:</strong> String<br>
-      <strong>Constant:</strong> optional<br>
+      <p class="properties"><strong>Type:</strong> String<br>
+        <strong>Constant:</strong> optional</p>
       <p>States that this PURL component is optional for a PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--version-definition-permitted-characters">
       <h1>Permitted characters in this PURL component</h1>
-      <br><strong>Location:</strong> /version_definition/permitted_characters<br>
-      <strong>Property:</strong> permitted_characters (Optional)<br>
-      <strong>Type:</strong> String<br>
-      <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a><br>
-      <p>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
+      <p class="properties"><strong>Location:</strong> /version_definition/permitted_characters<br>
+        <strong>Property:</strong> permitted_characters (Optional)<br>
+        <strong>Type:</strong> String<br>
+        <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a></p>
+      <p>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
     </emu-clause>
 
     <emu-clause id="sec--version-definition-case-sensitive">
       <h1>Case sensitive</h1>
-      <br><strong>Location:</strong> /version_definition/case_sensitive<br>
-      <strong>Property:</strong> case_sensitive (Optional)<br>
-      <strong>Type:</strong> Boolean<br>
-      <strong>Default Value:</strong> true<br>
+      <p class="properties"><strong>Location:</strong> /version_definition/case_sensitive<br>
+        <strong>Property:</strong> case_sensitive (Optional)<br>
+        <strong>Type:</strong> Boolean<br>
+        <strong>Default Value:</strong> true</p>
       <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--version-definition-normalization-rules">
       <h1>Normalization rules</h1>
-      <br><strong>Location:</strong> /version_definition/normalization_rules<br>
-      <strong>Property:</strong> normalization_rules (Optional)<br>
-      <strong>Type:</strong> array (of String)<br>
+      <p class="properties"><strong>Location:</strong> /version_definition/normalization_rules<br>
+        <strong>Property:</strong> normalization_rules (Optional)<br>
+        <strong>Type:</strong> array (of String)</p>
       <p>List of rules to normalize this component for this PURL type. These are plain text, unstructured rules as some require programming and cannot be enforced only with a schema. Tools are expected to apply these rules programmatically. Each item of this array must be a string.</p>
       <p><em>All items must be unique.</em></p>
     </emu-clause>
 
     <emu-clause id="sec--version-definition-native-name">
       <h1>Native name</h1>
-      <br><strong>Location:</strong> /version_definition/native_name<br>
-      <strong>Property:</strong> native_name (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /version_definition/native_name<br>
+        <strong>Property:</strong> native_name (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>The native name of this PURL component in the package ecosystem. For instance, the 'namespace' for the 'maven' type is 'groupId', and 'scope' for the 'npm' PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--version-definition-note">
       <h1>Note</h1>
-      <br><strong>Location:</strong> /version_definition/note<br>
-      <strong>Property:</strong> note (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /version_definition/note<br>
+        <strong>Property:</strong> note (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>Extra note text.</p>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec--qualifiers-definition">
     <h1>Qualifiers definition</h1>
-    <br><strong>Location:</strong> /qualifiers_definition<br>
-    <strong>Property:</strong> qualifiers_definition (Optional)<br>
-    <strong>Type:</strong> Array<br>
+    <p class="properties"><strong>Location:</strong> /qualifiers_definition<br>
+      <strong>Property:</strong> qualifiers_definition (Optional)<br>
+      <strong>Type:</strong> Array</p>
     <p>Definition of the qualifiers specific to this PURL type. The PURL qualifiers component is optional for a specific PURL type, but a qualifiers key or keys may be required for a specific PURL type. Each item of this array must be a Qualifiers definition object.</p>
 
     <emu-clause id="sec--qualifiers-definition-">
       <h1>Qualifiers definition</h1>
-      <br><strong>Location:</strong> /qualifiers_definition/[]<br>
-      <strong>Type:</strong> Object<br>
+      <p class="properties"><strong>Location:</strong> /qualifiers_definition/[]<br>
+        <strong>Type:</strong> Object</p>
       <p>The definition of a qualifier specific to this PURL type.</p>
 
       <emu-table>
@@ -1111,15 +1102,15 @@
 
       <emu-clause id="sec--qualifiers-definition-key">
         <h1>Qualifier key</h1>
-        <br><strong>Location:</strong> /qualifiers_definition/[]/key<br>
-        <strong>Type:</strong> String<br>
+        <p class="properties"><strong>Location:</strong> /qualifiers_definition/[]/key<br>
+          <strong>Type:</strong> String</p>
         <p>The key for the qualifier.</p>
       </emu-clause>
 
       <emu-clause id="sec--qualifiers-definition-requirement">
         <h1>Qualifier key requirement</h1>
-        <br><strong>Location:</strong> /qualifiers_definition/[]/requirement<br>
-        <strong>Type:</strong> String<br>
+        <p class="properties"><strong>Location:</strong> /qualifiers_definition/[]/requirement<br>
+          <strong>Type:</strong> String</p>
         <p>States that a PURL qualifier key is optional or required for a PURL type.</p>
         <p><em>Must be one of:</em></p>
         <ol>
@@ -1130,36 +1121,36 @@
 
       <emu-clause id="sec--qualifiers-definition-requirement-1">
         <h1>Component optional requirement</h1>
-        <strong>Type:</strong> String<br>
-        <strong>Constant:</strong> optional<br>
+        <p class="properties"><strong>Type:</strong> String<br>
+          <strong>Constant:</strong> optional</p>
         <p>States that this PURL component is optional for a PURL type.</p>
       </emu-clause>
 
       <emu-clause id="sec--qualifiers-definition-requirement-2">
         <h1>Component required requirement</h1>
-        <strong>Type:</strong> String<br>
-        <strong>Constant:</strong> required<br>
+        <p class="properties"><strong>Type:</strong> String<br>
+          <strong>Constant:</strong> required</p>
         <p>States that this PURL component is required for a PURL type.</p>
       </emu-clause>
 
       <emu-clause id="sec--qualifiers-definition-description">
         <h1>Description</h1>
-        <br><strong>Location:</strong> /qualifiers_definition/[]/description<br>
-        <strong>Type:</strong> String<br>
+        <p class="properties"><strong>Location:</strong> /qualifiers_definition/[]/description<br>
+          <strong>Type:</strong> String</p>
         <p>The description of this qualifier.</p>
       </emu-clause>
 
       <emu-clause id="sec--qualifiers-definition-default-value">
         <h1>Default value</h1>
-        <br><strong>Location:</strong> /qualifiers_definition/[]/default_value<br>
-        <strong>Type:</strong> String<br>
+        <p class="properties"><strong>Location:</strong> /qualifiers_definition/[]/default_value<br>
+          <strong>Type:</strong> String</p>
         <p>The optional default value of this qualifier if not provided.</p>
       </emu-clause>
 
       <emu-clause id="sec--qualifiers-definition-native-name">
         <h1>Native name</h1>
-        <br><strong>Location:</strong> /qualifiers_definition/[]/native_name<br>
-        <strong>Type:</strong> String<br>
+        <p class="properties"><strong>Location:</strong> /qualifiers_definition/[]/native_name<br>
+          <strong>Type:</strong> String</p>
         <p>The equivalent native name for this qualifier key.</p>
         <p><em>All items must be unique.</em></p>
       </emu-clause>
@@ -1168,9 +1159,9 @@
 
   <emu-clause id="sec--subpath-definition">
     <h1>Subpath definition</h1>
-    <br><strong>Location:</strong> /subpath_definition<br>
-    <strong>Property:</strong> subpath_definition (Optional)<br>
-    <strong>Type:</strong> Object<br>
+    <p class="properties"><strong>Location:</strong> /subpath_definition<br>
+      <strong>Property:</strong> subpath_definition (Optional)<br>
+      <strong>Type:</strong> Object</p>
     <p>The definition for the subpath for this PURL type. The PURL subpath component is optional for a specific PURL type definition.</p>
 
     <emu-table>
@@ -1194,7 +1185,7 @@
           <td>permitted_characters</td>
           <td>String</td>
           <td>Optional</td>
-          <td>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
+          <td>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</td>
         </tr>
         <tr>
           <td>case_sensitive</td>
@@ -1225,9 +1216,9 @@
 
     <emu-clause id="sec--subpath-definition-requirement">
       <h1>Subpath requirement</h1>
-      <br><strong>Location:</strong> /subpath_definition/requirement<br>
-      <strong>Property:</strong> requirement (Required)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /subpath_definition/requirement<br>
+        <strong>Property:</strong> requirement (Required)<br>
+        <strong>Type:</strong> String</p>
       <p>States that the PURL subpath is optional.</p>
       <p><em>Must be one of:</em></p>
       <ol>
@@ -1237,79 +1228,79 @@
 
     <emu-clause id="sec--subpath-definition-requirement-1">
       <h1>Component optional requirement</h1>
-      <strong>Type:</strong> String<br>
-      <strong>Constant:</strong> optional<br>
+      <p class="properties"><strong>Type:</strong> String<br>
+        <strong>Constant:</strong> optional</p>
       <p>States that this PURL component is optional for a PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--subpath-definition-permitted-characters">
       <h1>Permitted characters in this PURL component</h1>
-      <br><strong>Location:</strong> /subpath_definition/permitted_characters<br>
-      <strong>Property:</strong> permitted_characters (Optional)<br>
-      <strong>Type:</strong> String<br>
-      <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a><br>
-      <p>A regular expression (ECMA-262 dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
+      <p class="properties"><strong>Location:</strong> /subpath_definition/permitted_characters<br>
+        <strong>Property:</strong> permitted_characters (Optional)<br>
+        <strong>Type:</strong> String<br>
+        <strong>Format:</strong> A regular expression dialect defined by <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a></p>
+      <p>A regular expression (<a href="https://ecma-international.org/publications-and-standards/standards/ecma-262/">ECMA-262</a> dialect) defining the 'Permitted characters' for this component of this Package-URL type. If provided, this must be a subset of the 'Permitted characters' defined in the PURL specification.</p>
     </emu-clause>
 
     <emu-clause id="sec--subpath-definition-case-sensitive">
       <h1>Case sensitive</h1>
-      <br><strong>Location:</strong> /subpath_definition/case_sensitive<br>
-      <strong>Property:</strong> case_sensitive (Optional)<br>
-      <strong>Type:</strong> Boolean<br>
-      <strong>Default Value:</strong> true<br>
+      <p class="properties"><strong>Location:</strong> /subpath_definition/case_sensitive<br>
+        <strong>Property:</strong> case_sensitive (Optional)<br>
+        <strong>Type:</strong> Boolean<br>
+        <strong>Default Value:</strong> true</p>
       <p>true if this PURL component is case sensitive. If false, the canonical form must be lowercased.</p>
     </emu-clause>
 
     <emu-clause id="sec--subpath-definition-normalization-rules">
       <h1>Normalization rules</h1>
-      <br><strong>Location:</strong> /subpath_definition/normalization_rules<br>
-      <strong>Property:</strong> normalization_rules (Optional)<br>
-      <strong>Type:</strong> array (of String)<br>
+      <p class="properties"><strong>Location:</strong> /subpath_definition/normalization_rules<br>
+        <strong>Property:</strong> normalization_rules (Optional)<br>
+        <strong>Type:</strong> array (of String)</p>
       <p>List of rules to normalize this component for this PURL type. These are plain text, unstructured rules as some require programming and cannot be enforced only with a schema. Tools are expected to apply these rules programmatically. Each item of this array must be a string.</p>
       <p><em>All items must be unique.</em></p>
     </emu-clause>
 
     <emu-clause id="sec--subpath-definition-native-name">
       <h1>Native name</h1>
-      <br><strong>Location:</strong> /subpath_definition/native_name<br>
-      <strong>Property:</strong> native_name (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /subpath_definition/native_name<br>
+        <strong>Property:</strong> native_name (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>The native name of this PURL component in the package ecosystem. For instance, the 'namespace' for the 'maven' type is 'groupId', and 'scope' for the 'npm' PURL type.</p>
     </emu-clause>
 
     <emu-clause id="sec--subpath-definition-note">
       <h1>Note</h1>
-      <br><strong>Location:</strong> /subpath_definition/note<br>
-      <strong>Property:</strong> note (Optional)<br>
-      <strong>Type:</strong> String<br>
+      <p class="properties"><strong>Location:</strong> /subpath_definition/note<br>
+        <strong>Property:</strong> note (Optional)<br>
+        <strong>Type:</strong> String</p>
       <p>Extra note text.</p>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec--examples">
     <h1>PURL examples</h1>
-    <br><strong>Location:</strong> /examples<br>
-    <strong>Property:</strong> examples (Required)<br>
-    <strong>Type:</strong> array (of String)<br>
-    <strong>Pattern Constraint:</strong> <code class="pattern">^pkg:[a-z][a-z0-9-\.]+/.*$</code><br>
+    <p class="properties"><strong>Location:</strong> /examples<br>
+      <strong>Property:</strong> examples (Required)<br>
+      <strong>Type:</strong> array (of String)<br>
+      <strong>Pattern Constraint:</strong> <code class="pattern">^pkg:[a-z][a-z0-9-\.]+/.*$</code></p>
     <p>Example of valid, canonical PURLs for this package type. Each item of this array must be a string.</p>
     <p><em>All items must be unique.</em></p>
   </emu-clause>
 
   <emu-clause id="sec--note">
     <h1>Note</h1>
-    <br><strong>Location:</strong> /note<br>
-    <strong>Property:</strong> note (Optional)<br>
-    <strong>Type:</strong> String<br>
+    <p class="properties"><strong>Location:</strong> /note<br>
+      <strong>Property:</strong> note (Optional)<br>
+      <strong>Type:</strong> String</p>
     <p>Note about this PURL type.</p>
   </emu-clause>
 
   <emu-clause id="sec--reference-urls">
     <h1>Reference URLs</h1>
-    <br><strong>Location:</strong> /reference_urls<br>
-    <strong>Property:</strong> reference_urls (Optional)<br>
-    <strong>Type:</strong> array (of String)<br>
-    <strong>Format:</strong> URI as specified in <a href="https://www.ietf.org/rfc/rfc3986.html">RFC 3986</a><br>
+    <p class="properties"><strong>Location:</strong> /reference_urls<br>
+      <strong>Property:</strong> reference_urls (Optional)<br>
+      <strong>Type:</strong> array (of String)<br>
+      <strong>Format:</strong> URI as specified in <a href="https://www.ietf.org/rfc/rfc3986.html">RFC 3986</a></p>
     <p>Optional list of informational reference URLs about this PURL type. Each item of this array must be a string.</p>
     <p><em>All items must be unique.</em></p>
   </emu-clause>
@@ -1648,6 +1639,28 @@
   }
 }
 </code></pre>
+</emu-annex>
+
+<emu-annex id="sec-bibliography" back-matter>
+  <h1>Bibliography</h1>
+  <ul>
+    <li>
+      ECMA-262, <i>ECMAScript® language specification</i>, 16<sup>th</sup> Edition. Annex A.8: Grammar Summary for Regular Expressions<br>
+      <a href="https://262.ecma-international.org/16.0/index.html#sec-regular-expressions">https://262.ecma-international.org/16.0/index.html#sec-regular-expressions</a>
+    </li>
+    <li>
+      ECMA-404, <i>The JSON data interchange syntax</i><br>
+      <a href="https://www.ecma-international.org/publications-and-standards/standards/ecma-404/">https://www.ecma-international.org/publications-and-standards/standards/ecma-404/</a>
+    </li>
+    <li>
+      INCITS 4-1986 [R2022], <i>Information Systems - Coded Character Sets - 7-Bit Standard Code for Information Interchange (7-Bit ASCII)</i><br>
+      <a href="https://webstore.ansi.org/standards/incits/incits1986r2022">https://webstore.ansi.org/standards/incits/incits1986r2022</a>
+    </li>
+    <li>
+      IETF Draft, March 2018, <i>JSON Schema Validation: A Vocabulary for Structural Validation of JSON (Draft-07)</i><br>
+      <a href="https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01">https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01</a>
+    </li>
+  </ul>
 </emu-annex>
 
 <emu-annex id="sec-colophon" back-matter>


### PR DESCRIPTION
- Remove conformance clause re: RFC 2119 as discussed in Slack
- Move references with no mention in normative text from normative references to bibliography
- Add ECMA-262 to normative references
- Add ECMA-262 16th Edition annex A.8 to bibliography (aka RegEx dialect)
- Add links to references to ECMA-262
- Add paragraphs to properties sections
- Add 2025-specific print styles (this is labeled to specifically delete in future publications assuming that the text has changed enough to redistribute clauses among pages)
- identify booleans in prose to improve readability
  - (n.b. Please pay close attention to the change of booleans in properties tables as well. I consider that to be much of a stylistic choice and editors' prerogative. (see L647))
- Package-URL styling
  - (n.b. please see L246, the editors my wish to revert this line base on stylistic preferences)
