### PR TITLE
correct-list-items

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -309,9 +309,8 @@
           <li>PURL `type`, `namespace`, `name` and `version` components: these are collectively mapped to a URL `path`</li>
           <li>PURL `qualifiers`: this maps to a URL `query`</li>
           <li>PURL `subpath`: this is a URL `fragment`</li>
-          <li>In a PURL, there is no support for a URL Authority (e.g. no `username`, `password`, `host` and `port` components).</li>
         </ul>
-      </li>
+      </li>In a PURL, there is no support for a URL Authority (e.g. no `username`, `password`, `host` and `port` components).</li>
       <li>Special URL schemes as defined in https://url.spec.whatwg.org/ such as `file://`, `https://`, `http://` and `ftp://` are not valid PURL types. They are valid URL or URI schemes but they are not a valid PURL scheme. They may be used to reference URLs in separate attributes outside of a PURL or in a PURL qualifier.</li>
       <li>Version control system (VCS) URLs such `git://`, `svn://`, `hg://` or as defined in Python pip or SPDX download locations are not valid PURL types. They are valid URL or URI schemes but they are not a valid PURL scheme. They are a closely related, compact and uniform way to reference VCS URLs. They may be used as references in separate attributes outside of a PURL or in a PURL qualifier.</li>
     </ul>
@@ -353,8 +352,8 @@
       </li>
       <li>The following characters shall not be percent-encoded:
         <ul>
-          <li>the Alphanumeric Characters,</li>
-          <li>the Punctuation Characters,</li>
+          <li>the Alphanumeric Characters</li>
+          <li>the Punctuation Characters</li>
           <li>the Separator Characters when being used as PURL separators</li>
           <li>the colon ':', whether used as a Separator Character or otherwise</li>
           <li>the percent sign '%' when used to represent a percent-encoded character</li>
@@ -375,8 +374,8 @@
     <h1>Rules for each PURL component</h1>
     <p>A PURL string is an ASCII URL string composed of seven components. Except as expressly stated otherwise in this Clause, each component:</p>
     <ul>
-      <li>May be composed of any of the characters defined in the <emu-xref href="#sec-purl-specification-permitted-characters" title></emu-xref> clause</li>
-      <li>Shall be encoded as defined in the <emu-xref href="#sec-purl-specification-character-encoding" title></emu-xref> clause</li>
+      <li>may be composed of any of the characters defined in the <emu-xref href="#sec-purl-specification-permitted-characters" title></emu-xref> clause</li>
+      <li>shall be encoded as defined in the <emu-xref href="#sec-purl-specification-character-encoding" title></emu-xref> clause</li>
     </ul>
     <p>The "lowercase" rules are defined in the <emu-xref href="#sec-purl-specification-case-folding" title></emu-xref> clause.</p>
     <p>The rules for each component are:</p>
@@ -406,9 +405,9 @@
         <li>Each `namespace` segment shall be a percent-encoded string.</li>
         <li>When percent-decoded, a segment:
           <ul>
-            <li>Shall not contain any slash '/' characters</li>
-            <li>Shall not be empty</li>
-            <li>May contain any Unicode character other than '/' unless the package's `type` definition provides otherwise.</li>
+            <li>shall not contain any slash '/' characters</li>
+            <li>shall not be empty</li>
+            <li>may contain any Unicode character other than '/' unless the package's `type` definition provides otherwise</li>
           </ul>
         </li>
         <li>A URL host or Authority shall not be used as a `namespace`. Use instead a `repository_url` qualifier. Note however, that for some types, the `namespace` may look like a host.</li>
@@ -461,10 +460,10 @@
         <li>Each `subpath` segment shall be a percent-encoded string.</li>
         <li>When percent-decoded, a segment:
           <ul>
-            <li>Shall not contain any slash '/' characters</li>
-            <li>Shall not be empty</li>
-            <li>Shall not be any of '..' or '.'</li>
-            <li>May contain any Unicode character other than '/' unless the package's `type` definition provides otherwise.</li>
+            <li>shall not contain any slash '/' characters</li>
+            <li>shall not be empty</li>
+            <li>shall not be any of '..' or '.'</li>
+            <li>may contain any Unicode character other than '/' unless the package's `type` definition provides otherwise</li>
           </ul>
         </li>
         <li>The `subpath` shall be interpreted as relative to the root of the package.</li>


### PR DESCRIPTION
Corrected list items in sections 5.4, 5.6.3 and 5.6.7 to set initial caps to lower case and remove punctuation.
Outdented list item: "In a PURL, there is no support for a URL Authority (e.g. no username, password, host and port components)." because it is a sentence separate from the list items under the parent: "The PURL components are mapped to these URL components:"