### PR TITLE
added committee metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-only": "ecmarkup --verbose spec.html --multipage out",
     "build": "npm run build-head",
     "build-for-pdf": "ecmarkup --verbose spec.html --printable --assets external --assets-dir out out/index.html",
-    "pdf": "npm run prebuild-only && npm run build-for-pdf && prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/ECMA-PURL.pdf",
+    "pdf": "npm run prebuild-only && npm run build-for-pdf && prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/ECMA-427.pdf",
     "prebuild-snapshot": "npm run clean",
     "build-snapshot": "npm run build-head && node scripts/insert_snapshot_warning.js",
     "clean": "rm -rf out",

--- a/spec.html
+++ b/spec.html
@@ -123,6 +123,7 @@
   title: Package-URL (PURL) specification
   date: 2025-12-06
   shortname: ECMA-xxx
+  committee: 54
   status: standard
   location: https://tc54.org/ecmaXXX/
   markEffects: true
@@ -171,7 +172,6 @@
   </ul>
   <p>As software supply chain security becomes a global priority, formalizing PURL as an international standard ensures its adoption and consistent implementation. Standardization under Ecma International Technical Committee 54 (TC54) positions PURL as a foundational building block for secure, transparent, and efficient software ecosystems worldwide.</p>
   <p>By enabling a universally recognized and implementable specification, PURL aligns with global efforts to improve the security, reliability, and accountability of software supply chains. Its adoption ensures that organizations and developers can rely on a common language to manage software packages across the diverse and rapidly evolving software landscape.</p>
-  <p class="adoption-info">This Ecma Standard was developed by Technical Committee 54 and was adopted by the General Assembly of December 2025.</p>
 </emu-intro>
 
 <emu-clause id="sec-scope">

--- a/spec.html
+++ b/spec.html
@@ -122,24 +122,24 @@
 <pre class="metadata">
   title: Package-URL (PURL) specification
   date: 2025-12-06
-  shortname: ECMA-xxx
+  shortname: ECMA-427
   committee: 54
   status: standard
-  location: https://tc54.org/ecmaXXX/
+  location: https://tc54.org/purl/
   markEffects: true
   version: 1<sup>st</sup> Edition
 </pre>
 <p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
 <div id="metadata-block">
   <h1>About this specification</h1>
-  <p>The document at <a href="https://tc54.org/ecmaXXX/">https://tc54.org/ecmaXXX/</a> is the most accurate and up-to-date Package-URL specification.</p>
+  <p>The document at <a href="https://tc54.org/purl/">https://tc54.org/purl/</a> is the most accurate and up-to-date Package-URL specification.</p>
   <p>This document is available as <a href>a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
   <h1>Contributing to this specification</h1>
   <p>This specification is developed on GitHub with the help of the Package-URL community. There are a number of ways to contribute to the development of this specification:</p>
   <ul>
-    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL">https://github.com/Ecma-TC54/ECMA-xxx-PURL</a></li>
-    <li>Issues: <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/issues">All Issues</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/issues/new">File a New Issue</a></li>
-    <li>Pull Requests: <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/pulls">All Pull Requests</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/pulls/new">Create a New Pull Request</a></li>
+    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-427">https://github.com/Ecma-TC54/ECMA-427</a></li>
+    <li>Issues: <a href="https://github.com/Ecma-TC54/ECMA-427/issues">All Issues</a>, <a href="https://github.com/Ecma-TC54/ECMA-427/issues/new">File a New Issue</a></li>
+    <li>Pull Requests: <a href="https://github.com/Ecma-TC54/ECMA-427/pulls">All Pull Requests</a>, <a href="https://github.com/Ecma-TC54/ECMA-427/pulls/new">Create a New Pull Request</a></li>
     <li>
       Editors:
       <ul>
@@ -1663,6 +1663,6 @@
 
 <emu-annex id="sec-colophon" back-matter>
   <h1>Colophon</h1>
-  <p>This Standard is authored on <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this Standard are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
+  <p>This Standard is authored on <a href="https://github.com/Ecma-TC54/ECMA-427">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this Standard are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
   <p>We extend our gratitude to TC39 for their exceptional work in developing Ecmarkup, which has greatly facilitated TC54's successful adoption of this tool for the preparation and maintenance of our technical specifications.</p>
 </emu-annex>


### PR DESCRIPTION
Committee is now a metadata field in ecmarkup. If status is set to "standard", date and committee are required. ecmarkup will insert the adoption info note automatically.