### PR TITLE
Update ECMA-xxx references to ECMA-427

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -122,23 +122,23 @@
 <pre class="metadata">
   title: Package-URL (PURL) specification
   date: 2025-12-06
-  shortname: ECMA-xxx
+  shortname: ECMA-427
   status: standard
-  location: https://tc54.org/ecmaXXX/
+  location: https://tc54.org/purl/
   markEffects: true
   version: 1<sup>st</sup> Edition
 </pre>
 <p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
 <div id="metadata-block">
   <h1>About this specification</h1>
-  <p>The document at <a href="https://tc54.org/ecmaXXX/">https://tc54.org/ecmaXXX/</a> is the most accurate and up-to-date Package-URL specification.</p>
+  <p>The document at <a href="https://tc54.org/purl/">https://tc54.org/purl/</a> is the most accurate and up-to-date Package-URL specification.</p>
   <p>This document is available as <a href>a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
   <h1>Contributing to this specification</h1>
   <p>This specification is developed on GitHub with the help of the Package-URL community. There are a number of ways to contribute to the development of this specification:</p>
   <ul>
-    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL">https://github.com/Ecma-TC54/ECMA-xxx-PURL</a></li>
-    <li>Issues: <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/issues">All Issues</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/issues/new">File a New Issue</a></li>
-    <li>Pull Requests: <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/pulls">All Pull Requests</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL/pulls/new">Create a New Pull Request</a></li>
+    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-427">https://github.com/Ecma-TC54/ECMA-427</a></li>
+    <li>Issues: <a href="https://github.com/Ecma-TC54/ECMA-427/issues">All Issues</a>, <a href="https://github.com/Ecma-TC54/ECMA-427/issues/new">File a New Issue</a></li>
+    <li>Pull Requests: <a href="https://github.com/Ecma-TC54/ECMA-427/pulls">All Pull Requests</a>, <a href="https://github.com/Ecma-TC54/ECMA-427/pulls/new">Create a New Pull Request</a></li>
     <li>
       Editors:
       <ul>
@@ -1663,6 +1663,6 @@
 
 <emu-annex id="sec-colophon" back-matter>
   <h1>Colophon</h1>
-  <p>This Standard is authored on <a href="https://github.com/Ecma-TC54/ECMA-xxx-PURL">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this Standard are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
+  <p>This Standard is authored on <a href="https://github.com/Ecma-TC54/ECMA-427">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this Standard are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
   <p>We extend our gratitude to TC39 for their exceptional work in developing Ecmarkup, which has greatly facilitated TC54's successful adoption of this tool for the preparation and maintenance of our technical specifications.</p>
 </emu-annex>


### PR DESCRIPTION
- The https://tc54.org/ecmaXXX/ URL referenced at the top of the website is a dead link, update it to https://tc54.org/purl/
- Update all old https://github.com/Ecma-TC54/ECMA-xxx-PURL links to https://github.com/Ecma-TC54/ECMA-427

To fix #52 as reported by @mjherzog